### PR TITLE
modified margin to fit the contents

### DIFF
--- a/src/assets/styles/theme-fire.css
+++ b/src/assets/styles/theme-fire.css
@@ -1205,7 +1205,7 @@ video{max-width:100%;}
 .image-caption .caption:before{content:'' attr(data-caption) '';position:absolute;bottom:0;left:0;width:100%;height:100%;z-index:0;opacity:1;background:-moz-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(34, 34, 34, 0.7) 100%);background:-webkit-gradient(linear, left top, left bottom, color-stop(0%, rgba(0, 0, 0, 0)), color-stop(100%, rgba(34, 34, 34, 0.7)));background:-webkit-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(34, 34, 34, 0.7) 100%);background:-o-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(34, 34, 34, 0.7) 100%);background:-ms-linear-gradient(top, rgba(0, 0, 0, 0) 0%, rgba(34, 34, 34, 0.7) 100%);background:linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(34, 34, 34, 0.7) 100%);filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#e6222222', GradientType=0);}
 .image-caption.hover-caption .caption{opacity:0;transition:all 0.3s ease;-webkit-transition:all 0.3s ease;-moz-transition:all 0.3s ease;transform:translate3d(0, 100px, 0);-webkit-transform:translate3d(0, 100px, 0);-moz-transform:translate3d(0, 100px, 0);}
 .image-caption.hover-caption:hover .caption{opacity:1;transform:translate3d(0, 0, 0);-webkit-transform:translate3d(0, 0, 0);-moz-transform:translate3d(0, 0, 0);}
-.team.row{display:flex;flex-wrap:wrap;}
+.team.row{display:flex;flex-wrap:wrap;margin-right: 0px;}
 .filters{overflow:hidden;display:inline-block;}
 .filters li{float:left;margin-right:32px;cursor:pointer;font-family:"Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;border:2px solid #fc4f4f;padding:0 26px;height:40px;min-width:150px;line-height:36px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:1px;border-radius:0;color:#fc4f4f;text-align:center;transition:all 0.3s ease;-webkit-transition:all 0.3s ease;-moz-transition:all 0.3s ease;margin-right:8px;margin-bottom:24px;height:30px;font-size:11px;line-height:27px;min-width:0;border-color:rgba(255, 255, 255, 0);opacity:.7;border-radius:25px;-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;display:inline-block;}
 .filters li.active{border-color:#fc4f4f;opacity:1;}
@@ -1319,7 +1319,7 @@ footer.bg-dark a{color:#fff;}
 .bg-dark .back-to-top:active,
 .bg-dark .back-to-top:focus{color:#fff;}
 .bg-dark .back-to-top:hover{background:none;}
-.mr0{margin-right:0;!important;}
+.mr0{margin-right:0; !important;}
 .mb0{margin-bottom:0 !important;}
 .mb8{margin-bottom:8px;!important;}
 .mb16{margin-bottom:16px;!important;}


### PR DESCRIPTION
Fixes: #535 

As the contents were being trimmed, the styling is modified for the proper and complete view of the contents.

Screenshot for reference of the view after the commit:

![Screenshot at 2019-05-16 09-11-18](https://user-images.githubusercontent.com/36980003/57825013-a9ecc680-77ba-11e9-8568-cef9301dda3a.png)
