### PR TITLE
fix(angular-bootcamp): remove FAQ link

### DIFF
--- a/src/bootcamps/angular.json
+++ b/src/bootcamps/angular.json
@@ -33,10 +33,6 @@
         {
           "linkText": "Contents",
           "link": "#contents"
-        },
-        {
-          "linkText": "FAQ",
-          "link": "#faq"
         }
       ],
       "bgSrc": "/assets/images/cb/cover/cover3.jpg"


### PR DESCRIPTION
fixes #768 

Maybe, we don't need to remove that link, and just need to add these questions. Can anybody share info about that? @championswimmer  @witty123 @Prajjwal  ?