### PR TITLE
slider-container overlapping issue

### DIFF
--- a/src/partials/slider.hbs
+++ b/src/partials/slider.hbs
@@ -2,7 +2,7 @@
 <a id="slider" class="in-page-link"></a>
 <div class="a-cbm">
 	<div class="container">
-		<div class="slideshow-container" id="slider-container">
+		<div class="slideshow-container" style="margin-top:3rem;" id="slider-container">
 			{{#each slides}}
 			<div class="slideshow-container__slide">
 				<img src="{{#relativePath @file.path imgSrc}}{{/relativePath}} " class="w-100" alt="{{{imgAlt}}}">


### PR DESCRIPTION
In the slider section of the website below the navbar, the slider overlaps the navbar and cause visibility issues. I added the required margin to it and resolve that.

***before:***
![before](https://user-images.githubusercontent.com/64387054/104958671-74b86300-59f6-11eb-9da8-f84c9fda9a3c.gif)

see in this part how the slider underlaps the navbar which causes visibility issues to the user. because contents of the navbar are barely visible to the visitor.

***After:***
![after](https://user-images.githubusercontent.com/64387054/104958530-358a1200-59f6-11eb-97b5-d4a072c9b4b6.gif)
 
but after applying the appropriate margin to the slider, the contents of the navbar are visible 
